### PR TITLE
HBP: algorithm change (ditch outflow compensation)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,27 @@
 # erahumed (development version)
 
+### Algorithm
+
+In previous implementations of HBP, whenever there was a positive difference
+between the ditch's outflow, and the sum of the clusters ideal outflows, this 
+was compensated by sharing it uniformly among clusters (and adding equal amounts 
+of irrigation to these). We stop doing this and, instead, allow for the sum of 
+cluster outflows to be less than the corresponding ditch outflow. If we assume
+constant ditch water levels, this amounts to assuming that the difference comes
+from an independent source.
+
+### Visualization
+
+* HBP model component plot method: the height variable plotted is now 
+`height_sod_cm`, rather than `height_eod_cm` as before. This is done in order to 
+simplify visual comparisons between the plots for HBP and CT model components.
+
 ### New features
 
 * HBP model component output now also includes an `height_sod_cm` column, 
 representing the cluster's water level at "start-of-day".
 
-### Breaking changes
+### Breaking changes in API
 
 * Variable names refactors:
 
@@ -18,10 +34,6 @@ representing the cluster's water level at "start-of-day".
   
   * Former `real_inflow_cm/m3_s` and `real_outflow_cm/m3_s` are renamed 
   `inflow_cm/m3_s` and `outflow_cm/m3_s`, respectively.
-
-* HBP model component plot method: the height variable plotted is now 
-`height_sod_cm`, rather than `height_eod_cm` as before. This is done in order to 
-simplify visual comparisons between the plots for HBP and CT model components.
 
 # erahumed 0.9.0
 

--- a/R/hbp--logical-units.R
+++ b/R/hbp--logical-units.R
@@ -236,7 +236,13 @@ hbp_outflow_m3_s <- function(
   outflow_m3_s[ord] <- diff(cum_outflows)
   capacity_m3_s <- capacity_m3_s - cum_outflows[length(cum_outflows)]
 
-  outflow_m3_s <- outflow_m3_s + capacity_m3_s / length(outflow_m3_s)
+  # In an older version of the algorithm, we used to compensate for a positive
+  # difference between the ditch outflow and the sum of clusters ideal outflows,
+  # by sharing the extra outflow uniformly among clusters (and adjusting the
+  # inflow as required). This was implemented by the line below, which I leave
+  # here for the records. VG
+  #
+  # outflow_m3_s <- outflow_m3_s + capacity_m3_s / length(outflow_m3_s)
 
   return( list(outflow_m3_s = outflow_m3_s) )
 }

--- a/tests/testthat/_snaps/ca--main--large.md
+++ b/tests/testthat/_snaps/ca--main--large.md
@@ -3,5 +3,5 @@
     Code
       hash
     Output
-      [1] "7fb2eb026a867e6202db234e2cfb086c"
+      [1] "8a45357598f982746567256fd544d8ee"
 

--- a/tests/testthat/_snaps/ct--main--large.md
+++ b/tests/testthat/_snaps/ct--main--large.md
@@ -3,5 +3,5 @@
     Code
       hash
     Output
-      [1] "37e1678b0a697749f80f26048a1f7a9c"
+      [1] "a915fc8801d6a1fb38c8405db2fb300c"
 

--- a/tests/testthat/_snaps/hbp--main--large.md
+++ b/tests/testthat/_snaps/hbp--main--large.md
@@ -3,5 +3,5 @@
     Code
       hash
     Output
-      [1] "0f3d4e2c3aca3699337d4ee8589e45b8"
+      [1] "ee7ba257b02f5e6758389f36dbb68031"
 

--- a/tests/testthat/test-hbp--main--large.R
+++ b/tests/testthat/test-hbp--main--large.R
@@ -79,7 +79,7 @@ test_that("sum(real outflows) = total capacity of ditch", {
       .groups = "drop"
     ) |>
     dplyr::filter(
-      abs(outflow_m3_s - flowpoint) > mean(abs(flowpoint)) * 1e-10
+      abs(outflow_m3_s) > flowpoint + mean(flowpoint) * 1e-10
     )
 
   expect_equal(nrow(res), 0)


### PR DESCRIPTION
In previous implementations of HBP, whenever there was a positive difference between the ditch's outflow, and the sum of the clusters ideal outflows, this was compensated by sharing it uniformly among clusters (and adding equal amounts  of irrigation to these). We stop doing this and, instead, allow for the sum of cluster outflows to be less than the corresponding ditch outflow. If we assume constant ditch water levels, this amounts to assuming that the difference comes from an independent source.